### PR TITLE
Audio crackling fixes & Recording

### DIFF
--- a/pcm_sndio.c
+++ b/pcm_sndio.c
@@ -329,7 +329,7 @@ sndio_hw_params(snd_pcm_ioplug_t *io,
 
 	par->bps = SIO_BPS(par->bits);
 	par->rate = io->rate;
-	par->appbufsz = io->period_size;
+	par->appbufsz = io->buffer_size;
 
 	if (sio_setpar(sndio->hdl, par) == 0 ||
 	    sio_getpar(sndio->hdl, &retpar) == 0)


### PR DESCRIPTION
Fixes audio crackling when e.g. playing multiple youtube videos in browser by using the io->buffer_size instead of periods. Also adds recording. I don't know alsa very well at all so not sure if any of this is proper.

This PR doesn't fix mpv (though it has sndio backend, but would still be nice to have good compatibility).